### PR TITLE
eventのindex周りの修正

### DIFF
--- a/src/commands/event_channel.py
+++ b/src/commands/event_channel.py
@@ -325,7 +325,6 @@ async def add_event_role_member_impl(
     if not await validate_role_safety(ctx, role):
         return
 
-
     # 同名のチャンネルがEVENT_CATEGORY_NAMEカテゴリーに存在するか確認
     # {index}-で始まるチャンネルを検索
     event_channel = None


### PR DESCRIPTION
- ロールをindex名のみにする
- `add_event_role_member`で行うチャンネル名とロール名の一致判定(eventにそのロールが存在するか)をindexのみで行う 
  - 意図として、チャンネル名に使えない文字を使ってevent申請してた場合、ロール名にあってチャンネル名にない文字が存在し、一致判定ができないことが多かったです
  - clubに関しては依然として完全一致で見ているので直っていませんが、直近の課題としてeventがあったので、こちらを先に修正しました。