### PR TITLE
#チャンネル 指定でイベントのアーカイブ / 復元を直接実行できるように

### DIFF
--- a/src/commands/event_channel.py
+++ b/src/commands/event_channel.py
@@ -459,7 +459,7 @@ def setup(tree: app_commands.CommandTree):
         description="アーカイブされたイベントチャンネルをイベントカテゴリーに戻します",
     )
     @app_commands.describe(
-        channel_name="復元するイベントチャンネル名(デフォルトはコマンド実行チャンネル)"
+        channel_name="復元するイベントチャンネル（メンション形式、デフォルトはコマンド実行チャンネル）"
     )
     async def restore_event_channel(
         ctx: discord.Interaction, channel_name: discord.TextChannel | None = None


### PR DESCRIPTION
## 内容

タイトルの通りです。
従来のチャンネル名テキスト一致指定は削除しました。
想定カテゴリー外のチャンネルを指定した場合は、従来どおりエラーを返すことを検証済みです。

## 画像

### channel_nameをメンション指定した場合

<img width="1090" height="528" alt="スクリーンショット 2025-11-12 7 13 40" src="https://github.com/user-attachments/assets/42365500-23d4-4823-a9e9-276f567d618c" />

### channel_nameを省略した場合

<img width="1092" height="494" alt="スクリーンショット 2025-11-12 7 17 10" src="https://github.com/user-attachments/assets/6e599874-0e52-4ffd-9ab7-705e5bf07c49" />

### 想定カテゴリー外のチャンネルを指定した場合(エラー)

<img width="1068" height="556" alt="スクリーンショット 2025-11-12 7 18 03" src="https://github.com/user-attachments/assets/1a3134eb-5bc2-4096-8857-f11d75d20748" />
